### PR TITLE
Added composeWithDevTools and set trace to true

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "react-redux-feature": "^0.3.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
+    "redux-devtools-extension": "^2.13.8",
     "redux-events-middleware": "^1.5.2",
     "redux-thunk": "^2.3.0"
   },

--- a/packages/core/src/lib/create-ssr-state.js
+++ b/packages/core/src/lib/create-ssr-state.js
@@ -1,10 +1,10 @@
 import {
     createStore as createReduxStore,
     applyMiddleware,
-    compose,
     combineReducers,
 } from 'redux'
 import thunk from 'redux-thunk'
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly'
 
 import { ReduxEvents } from 'redux-events-middleware'
 import { createSSRContext } from './create-ssr-context'
@@ -58,13 +58,12 @@ export const createSSRState = (appReducers = {}, appFeatures = [], receivedSetti
         ]
 
         // @DEV: redux dev tools (development & client only)
+        let composeEnhancer
         const basicEnhancers = []
-        if (IS_BROWSER && process.env.NODE_ENV === 'development') {
-            const { __REDUX_DEVTOOLS_EXTENSION__ } = window
-
-            if (typeof __REDUX_DEVTOOLS_EXTENSION__ === 'function') {
-                basicEnhancers.push(__REDUX_DEVTOOLS_EXTENSION__())
-            }
+        if (IS_BROWSER) {
+            composeEnhancer = composeWithDevTools({ trace: true, traceLimit: 25 })
+        } else {
+            composeEnhancer = compose
         }
 
         const middlewares = settings.buildMiddlewares([
@@ -79,7 +78,7 @@ export const createSSRState = (appReducers = {}, appFeatures = [], receivedSetti
             ...settings.appendEnhancers,
         ])
 
-        const composedEnhancers = compose(
+        const composedEnhancers = composeEnhancer(
             applyMiddleware(...middlewares),
             ...enhancers,
         )

--- a/packages/core/src/lib/create-ssr-state.js
+++ b/packages/core/src/lib/create-ssr-state.js
@@ -1,6 +1,7 @@
 import {
     createStore as createReduxStore,
     applyMiddleware,
+    compose,
     combineReducers,
 } from 'redux'
 import thunk from 'redux-thunk'


### PR DESCRIPTION
- Changed to use composeWithDevTools if IS_BROWSER is `true`, else the ordinary compose is used.
- Uses composeWithDevTools that only runs in development
- Enabled trace mode to track which file dispatched an action.

# Not sure how to test this, please make sure it works before merge  🤙🏼