### PR TITLE
Fixes #18 and #19

### DIFF
--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -302,3 +302,41 @@ I would normally split this code into multiple files:
 
 With this setup a complex application can be takled by a large team with
 people working in paralle on clearly separated features.
+
+## Reference Hooks by Name
+
+A feature/service may register its hooks inside the hook app so that other
+services/features may refer to them by name instead of importing constants:
+
+```js
+const service1 = ({ registerHook, registerAction, createHook }) => {
+    
+    // Register the feature's hooks within the App's context
+    registerHook({ S1_START: 's1' })
+
+    registerAction({
+        hook: '$START_SERVICE',
+        handler: () => createHook.sync('s1')
+    })
+}
+
+// feature1 try to hook into "service1 > S1_START" using a
+// **strict reference**, the app would crash if that hook was not registersd
+const feature1 = ['$S1_START', () => { ... }]
+
+// feature2 try to hook into "service1 > S1_FOO" using a
+// **loose reference**, that hook does not exists, so the action is ignored
+const feature2 = ['$S1_FOO?', () => { ... }]
+
+runHookApp({
+    trace: 'compact',
+    services: [
+        service2,
+    ],
+    features: [
+        feature1,
+        feature2,
+    ],
+}).catch(err => console.error(err))
+```
+

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -15,7 +15,8 @@
     "@babel/core": "^7.5.5",
     "@forrestjs/babel-preset-package": "^3.7.3",
     "@marcopeg/utils": "^2.0.1",
-    "cross-env": "^5.1.4"
+    "cross-env": "^5.1.4",
+    "jest": "^24.9.0"
   },
   "homepage": "https://github.com/forrestjs/forrestjs/tree/master/packages/hooks#readme",
   "keywords": [
@@ -33,6 +34,7 @@
   "scripts": {
     "clean": "rm -rf node_modules && rm -f yarn.lock && rm -f package-lock.json",
     "test": "jest",
+    "tdd": "jest --watchAll",
     "build": "babel src --out-dir . --ignore **/__tests__",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__",

--- a/packages/hooks/src/__tests__/create-hook-app.js
+++ b/packages/hooks/src/__tests__/create-hook-app.js
@@ -142,4 +142,55 @@ describe('hooks/create-hook-app', () => {
         })
     })
 
+    describe('createHookApp / registerHook', () => {
+        const s1 = ({ registerHook, registerAction, createHook }) => {
+            registerHook({ S1: 's1' })
+            registerAction({
+                hook: '$START_SERVICE',
+                handler: () => createHook.sync('s1')
+            })
+        }
+
+        it('should run a required service by reference', async () => {
+            const handler = jest.fn()
+            const f1 = ['$S1', handler]
+    
+            await runHookApp({
+                services: [s1],
+                features: [f1],
+            })
+    
+            expect(handler.mock.calls.length).toBe(1)
+        })
+
+        it('should fail to run a required service by reference', async () => {
+            const handler = jest.fn()
+            const f1 = ['$S1', handler]
+
+            let error = null
+            try {
+                await runHookApp({
+                    // services: [s1],
+                    features: [f1],
+                })
+            } catch (e) {
+                error = e
+            }
+
+            expect(error.message).toBe('Unknown hook "S1"')
+        })
+
+        it('should ignore an optional service by reference', async () => {
+            const handler = jest.fn()
+            const f1 = ['$S1?', handler]
+
+            await runHookApp({
+                // services: [s1],
+                features: [f1],
+            })
+    
+            expect(handler.mock.calls.length).toBe(0)
+        })
+    })
+
 })

--- a/packages/hooks/src/lib/create-hooks-registry.js
+++ b/packages/hooks/src/lib/create-hooks-registry.js
@@ -16,9 +16,20 @@ const registries = {}
 export const createHooksRegistry = (initialHooks = {}, { registryName } = {}) => {
     const knownHooks = {}
 
+    // '$FOO'  - required reference (trigger error if not exists)
+    // '$FOO?' - optional reference (returns `null` if not exists)
     const getHook = (name) => {
-        if (knownHooks[name]) {
-            return knownHooks[name]
+        const isOptional = name.slice(-1) === '?'
+        const hookName = isOptional
+            ? name.substr(0, name.length - 1)
+            : name
+
+        if (knownHooks[hookName]) {
+            return knownHooks[hookName]
+        }
+
+        if (isOptional) {
+            return null
         }
 
         throw new Error(`Unknown hook "${name}"`)

--- a/packages/hooks/src/lib/register-action.js
+++ b/packages/hooks/src/lib/register-action.js
@@ -44,11 +44,18 @@ export const registerAction = (payload = {}, receivedHandler = null, receivedOpt
     }
     
     // Hooks name can be expressed as variables:
-    // '$FOO'
+    // '$FOO'  - required reference
+    // '$FOO?' - optional reference
     try {
         const hook = receivedHook.substr(0, 1) === '$'
             ? getHook(receivedHook.substr(1))
             : receivedHook
+
+        // the hook could be null in case of an optional reference was required
+        // '$FOO?'
+        if (hook === null) {
+            return
+        }
 
         const actionName = false
             || name

--- a/packages/service-postgres/README.md
+++ b/packages/service-postgres/README.md
@@ -2,28 +2,33 @@
 
 ForrestJS service which helps connecting to a Postgres server.
 
-    const services = [
-        require('@forrestjs/service-postgres'),
-    ]
+```js
+const { runHookApp } = require('@forrestjs/hooks')
+const serviceEnv = require('@forrestjs/service-env')
+const serviceLogger = require('@forrestjs/service-logger')
+const servicePostgres = require('@forrestjs/service-postgres')
 
-    registerAction({
-        hook: SETTINGS,
-        name: '♦ boot',
-        handler: ({ settings }) => {
-            settings.postgres.connections = [
-                {
-                    connectionName: 'default',
-                    host: config.get('PG_HOST'),
-                    port: config.get('PG_PORT'),
-                    database: config.get('PG_DATABASE'),
-                    username: config.get('PG_USERNAME'),
-                    password: config.get('PG_PASSWORD'),
-                    maxAttempts: Number(config.get('PG_MAX_CONN_ATTEMPTS', 25)),
-                    attemptDelay: Number(config.get('PG_CONN_ATTEMPTS_DELAY', 5000)),
-                    models: [],
-                },
-            ]
-            ...
+runHookApp({
+    settings: async ({ getEnv, setConfig }) => {
+        setConfig('postgres.connections', [{
+            connectionName: 'default',
+            host: getEnv('PG_HOST'),
+            port: getEnv('PG_PORT'),
+            database: getEnv('PG_DATABASE'),
+            username: getEnv('PG_USERNAME'),
+            password: getEnv('PG_PASSWORD'),
+            maxAttempts: Number(getEnv('PG_MAX_CONN_ATTEMPTS', 25)),
+            attemptDelay: Number(getEnv('PG_CONN_ATTEMPTS_DELAY', 5000)),
+            models: [], // optional
+        }])
+    },
+    services: [
+        serviceEnv,
+        serviceLogger,
+        servicePostgres,
+    ],
+}).catch(err => console.error(err))
+```
 
 ## Troubleshooting
 

--- a/packages/service-postgres/src/lib/index.js
+++ b/packages/service-postgres/src/lib/index.js
@@ -22,6 +22,12 @@ export default ({ registerHook, registerAction, createHook }) => {
             const postgres = getConfig('postgres.connections')
 
             for (const options of postgres) {
+
+                // #18 apply defaults to the models list
+                if (!options.models) {
+                    options.models = []
+                }
+
                 const name = `${hooks.POSTGRES_BEFORE_INIT}/${options.connectionName || 'default'}`
                 createHook.sync(name, { options })
                 await init(options, ctx)


### PR DESCRIPTION
#18 make `models = []` optional in a `postgres.connections` config
#19 let set a loose hook reference `$HOOK_NAME?`

Improves readmes