### PR TITLE
[hasura-client] getSQLErrorMessage throws an error when facing a data.code different than "postgres-error"

### DIFF
--- a/packages/service-hasura-client/src/errors-sql.js
+++ b/packages/service-hasura-client/src/errors-sql.js
@@ -1,7 +1,7 @@
 class HasuraSQLError extends Error {
   constructor(message, endpoint, secret, source, sql, originalError) {
     super(message);
-    this.name = "HasuraSQLError";
+    this.name = 'HasuraSQLError';
     this.endpoint = endpoint;
     this.secret = secret;
     this.source = source;
@@ -11,11 +11,11 @@ class HasuraSQLError extends Error {
 }
 
 const getSQLErrorMessage = (data) => {
-  if (data.code === "postgres-error") {
+  if (data.code === 'postgres-error') {
     return `${data.error}: ${data.internal.error.message}`;
   }
 
-  return error.message;
+  return `${data.code}: ${data.error}`;
 };
 
 class HasuraSQLPostgresError extends HasuraSQLError {
@@ -26,21 +26,21 @@ class HasuraSQLPostgresError extends HasuraSQLError {
       secret,
       source,
       sql,
-      error
+      error,
     );
-    this.name = "HasuraSQLPostgresError";
+    this.name = 'HasuraSQLPostgresError';
   }
 }
 
 class HasuraSQLRequestError extends HasuraSQLError {
   constructor(error, endpoint, secret, source, sql) {
-    super("Unknown GraphQL response", endpoint, secret, source, sql, error);
-    this.name = "HasuraSQLRequestError";
+    super('Unknown GraphQL response', endpoint, secret, source, sql, error);
+    this.name = 'HasuraSQLRequestError';
   }
 }
 
 module.exports = {
   HasuraSQLError,
   HasuraSQLPostgresError,
-  HasuraSQLRequestError
+  HasuraSQLRequestError,
 };


### PR DESCRIPTION
[PROBLEM]
When throwing a new HasuraSQLPostgresError, if the error code is different than "postgres-error, there will be a ReferenceError inside getSQLErrorMessage when accessing error.message, as error is not defined.

[SOLUTION]
Change it to `${data.code}: ${data.error}` in [packages/service-hasura-client/src/errors-sql.js:18](https://github.com/forrestjs/forrestjs/blob/ee4236096efd9072c15270927f10bc1c98aaf03a/packages/service-hasura-client/src/errors-sql.js#L18)

[HOW TO REPLICATE]
Call `hasura.sql` with the second argument being something different than a string (i.e., `await hasura.sql("SELECT * FROM mytable;", ["1", "2"])`)